### PR TITLE
feat(library): implement Phase-5 Learning Library dashboard with playlist progress grid

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,19 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  allowedDevOrigins: ["http://localhost:3000", "http://192.168.0.102:3000","http://192.168.0.101:3000"],
+  allowedDevOrigins: [
+    "http://localhost:3000",
+    "http://192.168.0.102:3000",
+    "http://192.168.0.101:3000",
+  ],
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "i.ytimg.com",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-icons": "^1.3.2",
         "@radix-ui/react-label": "^2.1.8",
+        "@radix-ui/react-progress": "^1.1.8",
         "@radix-ui/react-slot": "^1.2.4",
         "@tanstack/react-query": "^5.90.21",
         "@tanstack/react-query-devtools": "^5.91.3",
@@ -2233,6 +2234,45 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.8.tgz",
+      "integrity": "sha512-+gISHcSPUJ7ktBy9RnTqbdKW78bcGke3t6taawyZ71pio1JewwGSJizycs7rLhGTvMJYCQB1DBK4KQsxs7U8dA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress/node_modules/@radix-ui/react-context": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.3.tgz",
+      "integrity": "sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/react-label": "^2.1.8",
+    "@radix-ui/react-progress": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "@tanstack/react-query": "^5.90.21",
     "@tanstack/react-query-devtools": "^5.91.3",

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -1,10 +1,39 @@
+"use client"
+
+import { useQueryClient } from "@tanstack/react-query"
+
+import { Button } from "@/components/ui/button"
+import { LibraryGrid } from "@/features/library/components/LibraryGrid"
+import { useMyLibrary } from "@/features/library/hooks/use-my-library"
+
 export default function DashboardPage() {
+  const queryClient = useQueryClient()
+  const { playlists, isLoading, isError, refetch } = useMyLibrary()
+
+  const handleRefresh = () => {
+    queryClient.invalidateQueries({ queryKey: ["my-library"] })
+  }
+
   return (
-    <div className="space-y-2">
-      <h1 className="text-2xl font-semibold text-white">Dashboard</h1>
-      <p className="text-sm text-slate-400">
-        Welcome back. Your learning progress will appear here.
-      </p>
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-4 px-6 pt-6">
+        <div>
+          <h1 className="text-2xl font-semibold text-white">My Library</h1>
+          <p className="text-sm text-muted-foreground text-slate-400">
+            Continue where you left off and track your progress.
+          </p>
+        </div>
+        <Button variant="outline" onClick={handleRefresh}>
+          Refresh
+        </Button>
+      </div>
+
+      <LibraryGrid
+        playlists={playlists}
+        isLoading={isLoading}
+        isError={isError}
+        onRetry={refetch}
+      />
     </div>
-  );
+  )
 }

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import * as React from "react"
+import * as ProgressPrimitive from "@radix-ui/react-progress"
+
+import { cn } from "@/lib/utils"
+
+const Progress = React.forwardRef<
+  React.ElementRef<typeof ProgressPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
+>(({ className, value, ...props }, ref) => (
+  <ProgressPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative h-2 w-full overflow-hidden rounded-full bg-slate-800",
+      className
+    )}
+    {...props}
+  >
+    <ProgressPrimitive.Indicator
+      className="h-full w-full flex-1 bg-emerald-500 transition-all"
+      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+    />
+  </ProgressPrimitive.Root>
+))
+Progress.displayName = "Progress"
+
+export { Progress }

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,14 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-md bg-white/10", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/src/features/auth/hooks/use-auth-mutations.ts
+++ b/src/features/auth/hooks/use-auth-mutations.ts
@@ -15,7 +15,10 @@ type AuthResponse = {
     email?: string;
     avatar?: string | null;
   };
-  token: string;
+  tokens: {
+    accessToken: string;
+    refreshToken: string;
+  };
 };
 
 type AuthErrorResponse = {
@@ -38,7 +41,11 @@ export const useRegisterMutation = () => {
   return useMutation<AuthResponse, unknown, z.infer<typeof RegisterSchema>>({
     mutationFn: async (values) => AuthAPI.register(values),
     onSuccess: (data) => {
-      setAuth(data.user, data.token);
+      if (!data?.user || !data?.tokens?.accessToken) {
+        toast.error("Authentication failed. Please try again.");
+        return;
+      }
+      setAuth(data.user, data.tokens.accessToken);
       toast.success("Registration successful");
       router.replace("/dashboard");
     },
@@ -55,7 +62,11 @@ export const useLoginMutation = () => {
   return useMutation<AuthResponse, unknown, z.infer<typeof LoginSchema>>({
     mutationFn: async (values) => AuthAPI.login(values),
     onSuccess: (data) => {
-      setAuth(data.user, data.token);
+      if (!data?.user || !data?.tokens?.accessToken) {
+        toast.error("Authentication failed. Please try again.");
+        return;
+      }
+      setAuth(data.user, data.tokens.accessToken);
       toast.success("Welcome back");
       router.replace("/dashboard");
     },

--- a/src/features/auth/services/auth.api.ts
+++ b/src/features/auth/services/auth.api.ts
@@ -5,15 +5,28 @@ import { z } from "zod";
 type LoginPayload = z.infer<typeof LoginSchema>;
 type RegisterPayload = z.infer<typeof RegisterSchema>;
 
+type AuthPayload = {
+  user: {
+    id: string;
+    name?: string;
+    email?: string;
+    avatar?: string | null;
+  };
+  tokens: {
+    accessToken: string;
+    refreshToken: string;
+  };
+};
+
 export const AuthAPI = {
-  login: async (data: LoginPayload) => {
+  login: async (data: LoginPayload): Promise<AuthPayload> => {
     const response = await apiClient.post("/auth/login", data);
-    return response.data;
+    return response.data?.data;
   },
-  register: async (data: RegisterPayload) => {
+  register: async (data: RegisterPayload): Promise<AuthPayload> => {
     // Excluding confirmPassword before sending to backend if necessary
     const { confirmPassword, ...payload } = data;
     const response = await apiClient.post("/auth/register", payload);
-    return response.data;
+    return response.data?.data;
   },
 };

--- a/src/features/library/components/LibraryGrid.tsx
+++ b/src/features/library/components/LibraryGrid.tsx
@@ -1,0 +1,111 @@
+"use client"
+
+import Link from "next/link"
+import { PlayCircle } from "lucide-react"
+import { motion } from "framer-motion"
+
+import { Button } from "@/components/ui/button"
+
+import type { LibraryPlaylistProgressItem } from "../types/library.types"
+import { PlaylistCard } from "./PlaylistCard"
+import { PlaylistCardSkeleton } from "./PlaylistCardSkeleton"
+
+type LibraryGridProps = {
+  playlists: LibraryPlaylistProgressItem[]
+  isLoading: boolean
+  isError: boolean
+  onRetry: () => void
+}
+
+export function LibraryGrid({
+  playlists,
+  isLoading,
+  isError,
+  onRetry,
+}: LibraryGridProps) {
+  const gridVariants = {
+    hidden: { opacity: 0 },
+    show: {
+      opacity: 1,
+      transition: { staggerChildren: 0.06, delayChildren: 0.05 },
+    },
+  }
+
+  const cardVariants = {
+    hidden: { opacity: 0, y: 12, scale: 0.98 },
+    show: {
+      opacity: 1,
+      y: 0,
+      scale: 1,
+      transition: { type: "spring", stiffness: 220, damping: 22 },
+    },
+  }
+
+  if (isLoading) {
+    return (
+      <div className="container p-6">
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          {Array.from({ length: 6 }).map((_, index) => (
+            <PlaylistCardSkeleton key={index} />
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  if (isError) {
+    return (
+      <div className="container p-6">
+        <div className="rounded-xl border border-slate-800 bg-slate-900 p-8 text-center">
+          <h2 className="text-lg font-semibold text-white">
+            Something went wrong
+          </h2>
+          <p className="mt-2 text-sm text-muted-foreground text-slate-400">
+            We could not load your library. Please try again.
+          </p>
+          <Button onClick={onRetry} className="mt-4">
+            Retry
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  if (playlists.length === 0) {
+    return (
+      <div className="container flex min-h-[50vh] items-center justify-center p-6">
+        <div className="max-w-md text-center">
+          <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full border border-slate-800 bg-slate-900 text-indigo-400">
+            <PlayCircle className="h-7 w-7" />
+          </div>
+          <h2 className="mt-4 text-lg font-semibold text-white">
+            Your Library is Empty
+          </h2>
+          <p className="mt-2 text-sm text-muted-foreground text-slate-400">
+            Enroll in a playlist to begin focused learning.
+          </p>
+          <Button asChild className="mt-5">
+            <Link href="/dashboard/search">Explore Playlists</Link>
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="container p-6">
+      <motion.div
+        className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+        variants={gridVariants}
+        initial="hidden"
+        animate="show"
+      >
+        {playlists.map((playlist) => (
+          <motion.div key={playlist.enrollment_id} variants={cardVariants}>
+            <PlaylistCard playlist={playlist} />
+          </motion.div>
+        ))}
+      </motion.div>
+    </div>
+  )
+}

--- a/src/features/library/components/PlaylistCard.tsx
+++ b/src/features/library/components/PlaylistCard.tsx
@@ -1,0 +1,94 @@
+import Image from "next/image"
+import Link from "next/link"
+import { PlayCircle } from "lucide-react"
+
+import { Progress } from "@/components/ui/progress"
+import { cn } from "@/lib/utils"
+
+import type {
+  LibraryPlaylistProgressItem,
+  PlaylistThumbnailSource,
+} from "../types/library.types"
+
+type PlaylistCardProps = {
+  playlist: LibraryPlaylistProgressItem
+}
+
+const resolveThumbnailSource = (source?: PlaylistThumbnailSource) => {
+  if (!source) return ""
+  return typeof source === "string" ? source : source.url
+}
+
+const resolveThumbnailUrl = (playlist: LibraryPlaylistProgressItem) => {
+  return (
+    resolveThumbnailSource(playlist.thumbnails?.maxres) ||
+    resolveThumbnailSource(playlist.thumbnails?.high) ||
+    resolveThumbnailSource(playlist.thumbnails?.medium) ||
+    resolveThumbnailSource(playlist.thumbnails?.standard) ||
+    resolveThumbnailSource(playlist.thumbnails?.default) ||
+    ""
+  )
+}
+
+export function PlaylistCard({ playlist }: PlaylistCardProps) {
+  const thumbnailUrl = resolveThumbnailUrl(playlist)
+  const progressValue = Math.min(
+    100,
+    Math.max(0, playlist.progress_percentage || 0)
+  )
+
+  return (
+    <Link
+      href={`/dashboard/player/${playlist.playlist_id}`}
+      className="group block h-full"
+      aria-label={`Open ${playlist.title}`}
+    >
+      <div
+        className={cn(
+          "flex h-full flex-col gap-4 rounded-xl border border-slate-800 bg-slate-900 p-4 transition-all duration-200 ease-in-out",
+          "group-hover:scale-[1.02] group-hover:shadow-lg group-hover:shadow-black/30"
+        )}
+      >
+        <div className="relative overflow-hidden rounded-lg border border-slate-800 bg-slate-950/70">
+          <div className="relative w-full pb-[56.25%]">
+            {thumbnailUrl ? (
+              <Image
+                src={thumbnailUrl}
+                alt={playlist.title}
+                fill
+                sizes="(min-width: 1280px) 280px, (min-width: 1024px) 30vw, (min-width: 640px) 45vw, 90vw"
+                className="object-cover"
+              />
+            ) : (
+              <div className="absolute inset-0 flex items-center justify-center text-slate-400">
+                <PlayCircle className="h-10 w-10" />
+              </div>
+            )}
+          </div>
+
+          <div className="absolute right-3 top-3 rounded-full border border-slate-700 bg-slate-950/80 px-3 py-1 text-xs font-medium text-slate-200">
+            {playlist.total_videos} Videos
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <div>
+            <h3 className="text-lg font-semibold text-white line-clamp-2">
+              {playlist.title}
+            </h3>
+            <p className="text-sm text-muted-foreground text-slate-400">
+              {playlist.channelTitle}
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <Progress value={progressValue} />
+            <p className="text-xs text-muted-foreground text-slate-400">
+              {playlist.completed_videos} / {playlist.total_videos} videos completed
+            </p>
+          </div>
+        </div>
+      </div>
+    </Link>
+  )
+}

--- a/src/features/library/components/PlaylistCardSkeleton.tsx
+++ b/src/features/library/components/PlaylistCardSkeleton.tsx
@@ -1,0 +1,24 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export function PlaylistCardSkeleton() {
+  return (
+    <div className="flex h-full flex-col gap-4 rounded-xl border border-slate-800 bg-slate-900 p-4">
+      <div className="relative overflow-hidden rounded-lg border border-slate-800 bg-slate-950/70">
+        <div className="relative w-full pb-[56.25%]">
+          <Skeleton className="absolute inset-0" />
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <div className="space-y-2">
+          <Skeleton className="h-5 w-4/5" />
+          <Skeleton className="h-4 w-2/5" />
+        </div>
+        <div className="space-y-2">
+          <Skeleton className="h-2 w-full" />
+          <Skeleton className="h-3 w-1/2" />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/features/library/hooks/use-my-library.ts
+++ b/src/features/library/hooks/use-my-library.ts
@@ -1,0 +1,24 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+
+import { LibraryService } from "../services/library.service"
+import type { LibraryPlaylistProgressItem } from "../types/library.types"
+
+export const useMyLibrary = () => {
+  const query = useQuery({
+    queryKey: ["my-library"],
+    queryFn: () => LibraryService.getMyLibrary(),
+    staleTime: 1000 * 60 * 10,
+    refetchOnWindowFocus: false,
+  })
+
+  const playlists: LibraryPlaylistProgressItem[] = query.data?.data ?? []
+
+  return {
+    playlists,
+    isLoading: query.isLoading,
+    isError: query.isError,
+    refetch: query.refetch,
+  }
+}

--- a/src/features/library/services/library.service.ts
+++ b/src/features/library/services/library.service.ts
@@ -1,0 +1,15 @@
+import { apiClient } from "@/services/api-client"
+
+import type {
+  ApiResponse,
+  LibraryPlaylistProgressItem,
+} from "../types/library.types"
+
+export const LibraryService = {
+  getMyLibrary: async (): Promise<
+    ApiResponse<LibraryPlaylistProgressItem[]>
+  > => {
+    const response = await apiClient.get("/library/my-playlists")
+    return response.data
+  },
+}

--- a/src/features/library/types/library.types.ts
+++ b/src/features/library/types/library.types.ts
@@ -1,0 +1,36 @@
+export interface PlaylistThumbnail {
+  url: string
+  width: number
+  height: number
+}
+
+export type PlaylistThumbnailSource = PlaylistThumbnail | string
+
+export interface PlaylistThumbnailSet {
+  default?: PlaylistThumbnailSource
+  medium?: PlaylistThumbnailSource
+  high?: PlaylistThumbnailSource
+  standard?: PlaylistThumbnailSource
+  maxres?: PlaylistThumbnailSource
+}
+
+export interface LibraryPlaylistProgressItem {
+  enrollment_id: string
+  playlist_id: string
+  youtubePlaylistId: string
+  title: string
+  description?: string
+  channelTitle: string
+  thumbnails: PlaylistThumbnailSet
+  enrollment_status: string
+  enrolled_at: string
+  total_videos: number
+  completed_videos: number
+  progress_percentage: number
+}
+
+export interface ApiResponse<T> {
+  success: boolean
+  message: string
+  data: T
+}

--- a/src/store/use-auth-store.ts
+++ b/src/store/use-auth-store.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 import Cookies from "js-cookie";
+import { CONFIG } from "@/config/configEnv";
 
 type AuthUser = {
   id: string;
@@ -19,7 +20,7 @@ type AuthState = {
   hydrateAuth: () => void;
 };
 
-const AUTH_COOKIE_NAME = "focustube_token";
+const AUTH_COOKIE_NAME = CONFIG.auth.cookieName || "focustube-auth-token";
 
 const getSecureCookieFlag = () => {
   if (typeof window === "undefined") return true;


### PR DESCRIPTION
Phase-5 introduces the Learning Library Dashboard where users can view all playlists they have enrolled in and track their learning progress.

This feature integrates the backend Library API and implements a premium playlist grid UI following the FocusTube design system.

The dashboard will fetch enrolled playlists from the backend and render them as responsive playlist cards with progress indicators.

Objective

Build the My Library page that allows users to:

View enrolled playlists

Track video completion progress

Resume learning from playlists

Navigate to the learning player